### PR TITLE
Use Delorean for date and time handling.

### DIFF
--- a/feeds/items.py
+++ b/feeds/items.py
@@ -4,8 +4,8 @@ import scrapy
 
 
 class BaseItem(scrapy.Item):
-    # Required date format: RFC 3339
-    UPDATED_FMT = '%Y-%m-%dT%H:%M:%SZ'
+    # Required date format: RFC 3339 (ISO 8601 extended format)
+    UPDATED_FMT = 'Y-MM-ddTHH:mm:ssZZZZZ'
 
     # Required
     # The feed/entry id. It may be auto generated in case a link is present.
@@ -14,9 +14,9 @@ class BaseItem(scrapy.Item):
     # The feed/entry title.
     title = scrapy.Field()
 
-    # The last updated date of the feed as datetime object.
+    # The last updated date of the feed as Delorean object.
     updated = scrapy.Field(
-        serializer=lambda x: x.strftime(BaseItem.UPDATED_FMT))
+        serializer=lambda x: x.format_datetime(BaseItem.UPDATED_FMT))
 
     # Recommended
     author_name = scrapy.Field()

--- a/feeds/loaders.py
+++ b/feeds/loaders.py
@@ -1,10 +1,8 @@
 #!/usr/bin/python3
 
-import datetime
-
+import delorean
 import lxml
 from lxml.cssselect import CSSSelector
-import pytz
 from scrapy.loader import ItemLoader
 from scrapy.loader.processors import Join
 from scrapy.loader.processors import MapCompose
@@ -16,13 +14,11 @@ from feeds.items import FeedEntryItem
 
 
 def parse_datetime(text, loader_context):
-    datetime_format = loader_context.get('datetime_format', '%d.%m.%Y')
-    timezone = loader_context.get('timezone', pytz.UTC)
-    try:
-        return (timezone.localize(datetime.datetime.strptime(text,
-                datetime_format)).astimezone(pytz.UTC))
-    except ValueError:
-        return None
+    return delorean.parse(
+        text,
+        timezone=loader_context.get('timezone', 'UTC'),
+        dayfirst=loader_context.get('dayfirst', False),
+        yearfirst=loader_context.get('yearfirst', True)).shift('UTC')
 
 
 def build_tree(text, loader_context):

--- a/feeds/spiders/atv_at.py
+++ b/feeds/spiders/atv_at.py
@@ -4,7 +4,7 @@ import datetime
 import json
 
 from scrapy.spiders import Spider
-import pytz
+import delorean
 import scrapy
 
 from feeds.loaders import FeedEntryItemLoader
@@ -16,8 +16,7 @@ class AtvAtSpider(Spider):
     allowed_domains = ['atv.at']
     start_urls = ['http://atv.at/mediathek/neue-folgen/']
 
-    _datetime_format = '%d.%m.%Y %H:%M'
-    _timezone = pytz.timezone('Europe/Vienna')
+    _timezone = 'Europe/Vienna'
     _timerange = datetime.timedelta(days=7)
 
     def parse(self, response):
@@ -60,8 +59,8 @@ class AtvAtSpider(Spider):
         )
         il = FeedEntryItemLoader(response=response,
                                  base_url='http://{}'.format(self.name),
-                                 datetime_format=self._datetime_format,
-                                 timezone=self._timezone)
+                                 timezone=self._timezone,
+                                 dayfirst=True)
         il.add_value('link', data['clipurl'])
         il.add_value('title', data['programname'])
         il.add_value('updated', data['airdate'])
@@ -69,7 +68,7 @@ class AtvAtSpider(Spider):
         item = il.load_item()
         # Only include videos posted in the last 7 days.
         if (item['updated'] + self._timerange >
-                datetime.datetime.now(self._timezone)):
+                delorean.utcnow().shift(self._timezone)):
             yield item
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent autoindent

--- a/feeds/spiders/biblioweb_at_pettenbach.py
+++ b/feeds/spiders/biblioweb_at_pettenbach.py
@@ -47,7 +47,8 @@ class BibliowebAtPettenbachSpider(scrapy.Spider):
 
     def parse_content(self, response):
         parts = self._extract_parts(response)
-        il = FeedEntryItemLoader(response=response)
+        il = FeedEntryItemLoader(response=response, timezone='Europe/Vienna',
+                                 dayfirst=True)
         il.add_value('title', ' - '.join(parts[:self._find_first_meta(parts)]))
         il.add_value('link', response.url)
         il.add_xpath('updated', '//td/span/text()',

--- a/feeds/spiders/cbird_at.py
+++ b/feeds/spiders/cbird_at.py
@@ -20,7 +20,7 @@ class CbirdAtSpider(CrawlSpider):
     def parse_item(self, response):
         il = CbirdFeedEntryItemLoader(
             selector=response.xpath('//div[@class="main"]'),
-            datetime_format='%Y%m%d')
+            timezone='Europe/Vienna')
         il.add_xpath('title', 'h1/text()')
         il.add_value('link', response.url)
         il.add_xpath('content_html', 'h1/following-sibling::*')

--- a/feeds/spiders/meinbezirk_at.py
+++ b/feeds/spiders/meinbezirk_at.py
@@ -44,7 +44,8 @@ class MeinbezirkAtSpider(CrawlSpider):
 
         # Parse the actual content.
         il = FeedEntryItemLoader(response=response,
-                                 datetime_format='%d.%m.%Y, %H:%M',
+                                 timezone='Europe/Vienna',
+                                 dayfirst=True,
                                  remove_elems=['script', 'iframe'])
         il.add_value('link', response.url)
         il.add_xpath('title', '//div[@id="contentArea"]//h1/text()')

--- a/feeds/spiders/nzz_at.py
+++ b/feeds/spiders/nzz_at.py
@@ -5,7 +5,6 @@ import urllib.parse
 import json
 
 from scrapy.spiders import Spider
-import pytz
 import scrapy
 
 from feeds.loaders import FeedEntryItemLoader
@@ -17,8 +16,7 @@ class NzzAtSpider(Spider):
     allowed_domains = ['nzz.at']
     start_urls = ['https://nzz.at/wp/wp-login.php']
 
-    _datetime_format = '%Y-%m-%d %H:%M:%S'
-    _timezone = pytz.timezone('GMT')
+    _timezone = 'GMT'
     _excluded = []
     _max_items = 20
     _num_items = 0
@@ -57,13 +55,11 @@ class NzzAtSpider(Spider):
         yield scrapy.Request(url, callback=self._parse_ajax_url)
 
     def _create_error_item(self, title, body):
-        il = FeedEntryItemLoader(datetime_format=self._datetime_format,
-                                 timezone=self._timezone)
+        il = FeedEntryItemLoader(timezone=self._timezone)
         il.add_value('link', self.start_urls[0])
         il.add_value('title', title)
         il.add_value('content_html', body)
-        il.add_value('updated',
-                     datetime.utcnow().strftime(self._datetime_format))
+        il.add_value('updated', str(datetime.utcnow()))
         return il.load_item()
 
     def _parse_ajax_url(self, response):
@@ -86,7 +82,6 @@ class NzzAtSpider(Spider):
 
     def parse_item(self, response):
         il = FeedEntryItemLoader(response=response,
-                                 datetime_format=self._datetime_format,
                                  timezone=self._timezone,
                                  base_url='http://{}'.format(self.name))
         article = json.loads(response.body_as_unicode())['data']

--- a/feeds/spiders/oe1_orf_at.py
+++ b/feeds/spiders/oe1_orf_at.py
@@ -3,7 +3,6 @@
 import json
 
 from scrapy.spiders import Spider
-import pytz
 import scrapy
 
 from feeds.loaders import FeedEntryItemLoader
@@ -15,8 +14,7 @@ class Oe1OrfAtSpider(Spider):
     allowed_domains = ['oe1.orf.at']
     start_urls = ['http://oe1.orf.at/programm/konsole/heute']
 
-    _datetime_format = '%d.%m.%Y %H:%M'
-    _timezone = pytz.timezone('Europe/Vienna')
+    _timezone = 'Europe/Vienna'
 
     def parse(self, response):
         il = FeedItemLoader()
@@ -38,7 +36,6 @@ class Oe1OrfAtSpider(Spider):
     def parse_item(self, response):
         for item in json.loads(response.body_as_unicode())['list']:
             il = FeedEntryItemLoader(response=response,
-                                     datetime_format=self._datetime_format,
                                      timezone=self._timezone,
                                      base_url='http://{}'.format(self.name))
             if 'url_json' not in item:

--- a/feeds/spiders/tips_at.py
+++ b/feeds/spiders/tips_at.py
@@ -24,7 +24,9 @@ class TipsAtSpider(CrawlSpider):
     def parse_item(self, response):
         il = FeedEntryItemLoader(response=response,
                                  base_url='http://{}'.format(self.name),
-                                 remove_elems=['script'])
+                                 remove_elems=['script'],
+                                 timezone='Europe/Vienna',
+                                 dayfirst=True)
         il.add_value('link', response.url)
         il.add_xpath('title', '//h1[@class="article-title"]/text()')
         il.add_xpath('author_name', '//div[@class="calendar-time"]/a/text()')

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
 Click>=6.6
+Delorean>=0.6.0
 Scrapy>=1.1
-pytz>=2016.4
 lxml>=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ setup(
     include_package_data=True,
     install_requires=[
         'Click>=6.6',
+        'Delorean>=0.6.0',
         'Jinja2>=2.8',
         'Scrapy>=1.1.0rc3',
-        'pytz>=2016.4',
         'lxml>=3.5.0',
     ],
     entry_points='''


### PR DESCRIPTION
I've refactored all spiders and the loader to use Delorean (http://delorean.readthedocs.io/) for handling date and time.

Delorean is a thin wrapper around pytz, dateutil and babel and provides a clean and easy to use API. Parsing works without specifying a format string.

For ambiguous dates FeedEntryItemLoader parameters `dayfirst` and `yearfirst` have been added:

* `dayfirst` is `False` by default, i.e. `2016-05-03` is interpreted as `May 3, 2016`. However, `05.03.2016` is also interpreted as `May 3, 2016` which is usually wrong for German dates so `dayfirst` has to be set to `True` in these cases.
* `yearfirst` is `True` by default, i.e. `05-04-03` is interpreted as `April 3, 2005`.

Closes: #18 
