### PR TITLE
Add "paywalled" tag to article items

### DIFF
--- a/feeds/spiders/falter_at.py
+++ b/feeds/spiders/falter_at.py
@@ -73,7 +73,7 @@ class FalterAtSpider(Spider):
                 title = item['title']
             il.add_value('title', title)
             # All articles have the same date.
-            # We add an offset they are sorted in the right order.
+            # We add an offset so they are sorted in the right order.
             date = (delorean.parse(item['date'], dayfirst=False,
                                    timezone=self._timezone) +
                     timedelta(hours=17, seconds=i)).format_datetime(
@@ -89,7 +89,10 @@ class FalterAtSpider(Spider):
                                  parent=response.meta['il'],
                                  remove_elems=remove_elems,
                                  base_url='http://{}'.format(self.name))
-        il.add_xpath('content_html', '//article')
+        content = response.xpath('//article').extract_first()
+        if 'Lesen Sie diesen Artikel in voller Länge' in content:
+            il.add_value('category', 'paywalled')
+        il.add_value('content_html', content)
         yield il.load_item()
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent autoindent

--- a/feeds/spiders/konsument_at.py
+++ b/feeds/spiders/konsument_at.py
@@ -51,6 +51,11 @@ class KonsumentAtSpider(Spider):
                                  callback=self._parse_article_url)
 
     def _parse_article_url(self, response):
+        if 'Fehler' in response.css('h2 ::text').extract_first():
+            self.logger.info('Skipping {} as it returned an error'.format(
+                             response.url))
+            return
+
         remove_elems = ['div[style="padding-top:10px;"]']
         il = FeedEntryItemLoader(response=response,
                                  timezone=self._timezone,

--- a/feeds/spiders/konsument_at.py
+++ b/feeds/spiders/konsument_at.py
@@ -64,14 +64,13 @@ class KonsumentAtSpider(Spider):
         il.add_value('updated', date)
         url = (response.xpath('//a[text()="Druckversion"]/@onclick').
                re_first(r"window\.open\('(.*)'\);"))
-        title = response.css('h1::text').extract_first()
+        il.add_css('title', 'h1::text')
         if url:
-            il.add_value('title', title)
             yield scrapy.Request(response.urljoin(url),
                                  callback=self._parse_article,
                                  meta={'il': il})
         else:
-            il.add_value('title', '[€] ' + title)
+            il.add_value('category', 'paywalled')
             il.add_css('content_html', '.primary')
             il.add_css('content_html', 'div[style="padding-top:10px;"] > h3')
             yield il.load_item()


### PR DESCRIPTION
Instead of prefixing paywalled article titles with "[€]" it is more clean to add a "paywalled" tag.