### PR TITLE
Rename feed_header() to generate_feed_header().

### DIFF
--- a/feeds/pipelines.py
+++ b/feeds/pipelines.py
@@ -77,7 +77,7 @@ class AtomExportPipeline(object):
 
     def spider_closed(self, spider):
         # Add feed header(s) at the end so they can be dynamic.
-        for feed_header in iterate_spider_output(spider.feed_header()):
+        for feed_header in iterate_spider_output(spider.feed_headers()):
             self._exporters[spider].export_item(feed_header)
         self._exporters[spider].finish_exporting()
         self._exporters.pop(spider)

--- a/feeds/spiders/__init__.py
+++ b/feeds/spiders/__init__.py
@@ -6,8 +6,9 @@ from feeds.loaders import FeedItemLoader
 
 class FeedsSpider(Spider):
 
-    def feed_header(self, title=None, subtitle=None, link=None, path=None,
-                    author_name=None, icon=None, logo=None):
+    def generate_feed_header(self, title=None, subtitle=None, link=None,
+                             path=None, author_name=None, icon=None,
+                             logo=None):
         il = FeedItemLoader()
         il.add_value('title', title or getattr(self, '_title', self.name))
         il.add_value('subtitle', subtitle or getattr(self, '_subtitle', None))
@@ -20,6 +21,9 @@ class FeedsSpider(Spider):
         il.add_value('icon', icon or getattr(self, '_icon', None))
         il.add_value('logo', logo or getattr(self, '_logo', None))
         return il.load_item()
+
+    def feed_headers(self):
+        return self.generate_feed_header()
 
 
 class FeedsCrawlSpider(CrawlSpider, FeedsSpider):


### PR DESCRIPTION
This way a subclass can overwrite feed_headers() and still use
generate_feed_header().