### PR TITLE
Sometimes there is a space at the end of the link which leads to a 404.

### DIFF
--- a/feeds/spiders/orf_at.py
+++ b/feeds/spiders/orf_at.py
@@ -101,7 +101,8 @@ class OrfAtSpider(FeedsXMLFeedSpider):
             ):
                 self.logger.debug("Ignoring link to '{}'".format(link))
             else:
-                yield scrapy.Request(link, self._parse_article, meta=meta)
+                # Sometimes there is a space at the end of a link ...
+                yield scrapy.Request(link.strip(), self._parse_article, meta=meta)
 
     def _parse_article(self, response):
         try:


### PR DESCRIPTION
E.g. "https://religion.orf.at/stories/2921546/ "