### PR TITLE
cbird.at: the date might occur multiple times

### DIFF
--- a/feeds/spiders/cbird_at.py
+++ b/feeds/spiders/cbird_at.py
@@ -22,7 +22,7 @@ class CbirdAtSpider(FeedsCrawlSpider):
         il.add_xpath("title", "h1/text()")
         il.add_value("link", response.url)
         il.add_xpath("content_html", "h1/following-sibling::*")
-        il.add_value("updated", response.url.split("/")[-1])
+        il.add_value("updated", response.url.split("/")[-1].split("_")[0])
         il.add_value("author_name", self.name)
         yield il.load_item()
 


### PR DESCRIPTION
There might be multiple versions for a single day.
Those are separated via '_' followed by an index.
Simply strip the index.